### PR TITLE
Removed static flag

### DIFF
--- a/solver/Makefile
+++ b/solver/Makefile
@@ -12,7 +12,7 @@ DEPS      = $(SRCS:.cpp=.d)
 .PHONY: all debug clean
 
 all: CXXFLAGS += -O3 -DNDEBUG
-all: LIBS := -static $(LIBS)
+all: LIBS := $(LIBS)
 all: $(EXEC)
 
 debug: CXXFLAGS += -O0 -g3


### PR DESCRIPTION
Without the flag, this fixes the issue of the build not compiling on MacOs High Sierra (possibly older versions too)